### PR TITLE
Fix MODULE.bazel and the parser test

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,3 +1,3 @@
 bazel_dep(name = "googletest", version = "1.16.0")
-
 bazel_dep(name = "glog", version = "0.7.1")
+

--- a/parser/parser.cc
+++ b/parser/parser.cc
@@ -8,17 +8,20 @@ namespace simp {
 std::unique_ptr<KeywordToken> Parser::expect_keyword(
     const std::string& keyword) {
   std::unique_ptr<Token> token = std::move(tokens_.front());
+  tokens_.pop_front(); // Always pop the front token first
+
   if (!token) {
     LOG(INFO) << "----------expect_keyword \"" << keyword << "\" not found";
+    tokens_.push_front(std::move(token));
     return nullptr;
   }
+
   if (token->type() == TokenType::KEYWORD) {
     LOG(INFO) << "----------expect_keyword keyword found";
     const auto& keyword_token = static_cast<KeywordToken*>(token.get());
 
     if (keyword_token->keyword() == keyword) {
       LOG(INFO) << "----------expect_keyword \"" << keyword << "\" match found";
-      tokens_.pop_front();
       return std::make_unique<KeywordToken>(keyword_token);
     } else {
       LOG(INFO) << "----------expect_keyword actual keyword: "
@@ -27,6 +30,7 @@ std::unique_ptr<KeywordToken> Parser::expect_keyword(
       return nullptr;
     }
   }
+  tokens_.push_front(std::move(token));
   return nullptr;
 }
 


### PR DESCRIPTION
My very shallow understanding is that when you `std::move` the token out of the queue, it's now invalid in the queue, so if you want to keep it in the queue, you have to push it back.

If you're just doing that `std::move` as an optimization, I advise against it. The performance of the parser will likely not be an issue.

I figured this out with Claude Code, btw.  This is the prompt I gave it:

```
Running the parser tests fails:

  bazel test //parser:parser_test

  The lexer seems to work fine, but I'm running into a memory issue with the parser. The parser works on a deque of unique_ptr<Token> (deque because I sometimes need to put
  back a token in the front). I know what the problem is but it doesn't make sense that the situation is possible: when parsing "let a = 1 and b = 2 and c = 3 in a+(b*c)
  end", I seem to get get all of the bindings, but when I look for the expression after the "in" token, I pop the next token and std::move it to another variable, and
  somehow that variable is a nullptr

  Can you please figure out what's wrong?
```

I ended up doing all sorts of other shit, too, but its changes did include this fix, and I really didn't have to do much at all, except figure out which of the changes were actually responsible.  Maybe I should have asked it to do that, too.